### PR TITLE
fixing events with same date to appear together

### DIFF
--- a/src/components/event_list.js
+++ b/src/components/event_list.js
@@ -21,7 +21,7 @@ class EventList extends Component {
           onEventListItemClick={this.props.onEventListItemClick}
         />];
         if (i >= 1) {
-          this.isSameDay = this.prevDate === event.date;
+          this.isSameDay = this.prevDate.isSame(event.date);
         }
         if (i === 0 || (i >= 1 && !this.isSameDay)) {
           this.eventItems.push(


### PR DESCRIPTION
Fixed issue where two events with the same date were not appearing under a single date line in the side bar.