### PR TITLE
selected circle button fixed - before it moved around other icons wit…

### DIFF
--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -405,8 +405,8 @@ hr {
 }
 
 .selected-icon {
-  height: 30px;
-  width: 30px;
+  //height: 30px;
+  //width: 30px;
 }
 
 // Generic Classes


### PR DESCRIPTION
…h it and did not form a perfectly centered circle around the selected event map icon

Fixed by simply commenting out a predefined height and width value for .selected-icon

PR in reference to #159 

Before bug fix:
![before_mappit](https://cloud.githubusercontent.com/assets/9056425/22772547/352b62fa-ee6b-11e6-8adf-0c903020f1dd.png)

After bug fix:
![after_mappit](https://cloud.githubusercontent.com/assets/9056425/22772485/f10c3d1a-ee6a-11e6-8db2-2f3faa3a004b.png)
