### PR TITLE
Jun select button bug fix

### DIFF
--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -405,8 +405,8 @@ hr {
 }
 
 .selected-icon {
-  //height: 30px;
-  //width: 30px;
+  height: initial;
+  width: initial;
 }
 
 // Generic Classes


### PR DESCRIPTION
Proposed bug fix for issue #159 

Before the fix, the select button did not form a perfect perimeter around the selected event icon and the placement of the select button shifted around event icons. 

Set values for .selected_icon{} width and height as 'initial' instead of '30px'. This was causing a problem.

**Before fix:** 
![before_mappit](https://cloud.githubusercontent.com/assets/9056425/22772713/5117f644-ee6c-11e6-9f6d-0cef686e42cb.png)

**After fix:**
![after_mappit](https://cloud.githubusercontent.com/assets/9056425/22772720/5b0f89be-ee6c-11e6-9d92-077eb64bc66b.png)
