### PR TITLE
Jun event overlap in right column bug fix

### DIFF
--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -241,7 +241,7 @@ hr {
 .event-item {
   background-color: white;
   border-bottom: thin solid black;
-  //height: 100%;
+  height: 100%;
   padding-left: 8px;
   padding-top: 8px;
   width: 100%;


### PR DESCRIPTION
Proposed fix in reference to issue #155 

Fixed by setting height value to 100% in .event-item{}

**Before bug fix:**
![mappit_events_before](https://cloud.githubusercontent.com/assets/9056425/22773213/e00b49a8-ee6e-11e6-9e66-db6adb01bde2.png)

**After bug fix:**
![mappit_events_after](https://cloud.githubusercontent.com/assets/9056425/22773223/eb30b980-ee6e-11e6-806a-584c5777e7a6.png)
